### PR TITLE
changed timeout of runner to 30sec from 10sec

### DIFF
--- a/lib/server/runner.rb
+++ b/lib/server/runner.rb
@@ -18,7 +18,7 @@ module Testbot::Server
     end
 
     def self.timeout
-      10
+      30
     end
 
     def self.find_by_uid(uid)


### PR DESCRIPTION
to avoid releasing jobs when there's temporal network lag
