### PR TITLE
make groups smaller, for equaller time of jobs between runners

### DIFF
--- a/lib/server/group.rb
+++ b/lib/server/group.rb
@@ -13,7 +13,7 @@ module Testbot::Server
       current_group, current_size = 0, 0
       tests_with_sizes.each do |test, size|
         # inserts into next group if current is full and we are not in the last group
-        if (0.5*size + current_size) > group_size(tests_with_sizes, instance_count) and instance_count > current_group + 1
+        if (0.5*size + current_size) > group_size(tests_with_sizes, group_count(instance_count, 0.5))
           current_size = size
           current_group += 1
         else
@@ -27,6 +27,10 @@ module Testbot::Server
     end
 
     private
+
+    def self.group_count(instance_count, initial_allocate_ratio=1.0)
+      instance_count.to_f / initial_allocate_ratio.to_f
+    end
 
     def self.group_size(tests_with_sizes, group_count)
       total = tests_with_sizes.inject(0) { |sum, test| sum += test[1] }


### PR DESCRIPTION
groupの粒度をより細かくすることで、runner間の負荷を平均化したい。
