### PR TITLE
[#107884290] status表示変更、jobのログ追加

### DIFF
--- a/lib/runner/job.rb
+++ b/lib/runner/job.rb
@@ -62,10 +62,6 @@ module Testbot::Runner
       end
     end
 
-    def put_to_server output, body
-      Server.put("/jobs/#{@id}", body: {result: SafeResultText.clean(output)}.merge(body) )
-    end
-
     private
 
     def kill_processes
@@ -87,6 +83,10 @@ module Testbot::Runner
       put_to_server output, {status: "building"}
     rescue Timeout::Error
       puts "Got a timeout when posting an job result update. This can happen when the server is busy and is not a critical error."
+    end
+
+    def put_to_server output, body={}
+      Server.put("/jobs/#{@id}", body: {result: SafeResultText.clean(output)}.merge(body) )
     end
 
     def run_and_return_result(command)

--- a/lib/runner/job.rb
+++ b/lib/runner/job.rb
@@ -30,7 +30,7 @@ module Testbot::Runner
         result += run_and_return_result("#{base_environment} #{adapter.command(@project, ruby_cmd, @files)}")
       end
 
-      Server.put("/jobs/#{@id}", :body => { :result => SafeResultText.clean(result), :status => status, :time => run_time })
+      put_to_server result, {status: status, time: run_time}
       puts "Job #{@id} finished."
     end
 
@@ -39,6 +39,31 @@ module Testbot::Runner
         kill_processes
         @killed = true
       end
+    end
+
+    def fetch_code
+      put_to_server "", {status: "fetching-code (rsync)"}
+      system "rsync -az --timeout=300 --delete --delete-excluded -e ssh #{root}/ #{project}"
+    end
+
+    def before_run max_instances
+      put_to_server "", {status: "before-run"}
+      rvm_prefix = RubyEnv.rvm_prefix(project)
+      bundler_cmd = (RubyEnv.bundler?(project) ? [rvm_prefix, "bundle &&", rvm_prefix, "bundle exec"] : [rvm_prefix]).compact.join(" ")
+      command_prefix = "cd #{project} && export RAILS_ENV=test && export TEST_INSTANCES=#{max_instances} && #{bundler_cmd}"
+
+      if File.exists?("#{project}/lib/tasks/testbot.rake")
+        system "#{command_prefix} rake testbot:before_run"
+      elsif File.exists?("#{project}/config/testbot/before_run.rb")
+        system "#{command_prefix} ruby config/testbot/before_run.rb"
+      else
+        # workaround to bundle within the correct env
+        system "#{command_prefix} ruby -e ''"
+      end
+    end
+
+    def put_to_server output, body
+      Server.put("/jobs/#{@id}", body: {result: SafeResultText.clean(output)}.merge(body) )
     end
 
     private
@@ -59,7 +84,7 @@ module Testbot::Runner
     end
 
     def post_results(output)
-      Server.put("/jobs/#{@id}", :body => { :result => SafeResultText.clean(output), :status => "building" })
+      put_to_server output, {status: "building"}
     rescue Timeout::Error
       puts "Got a timeout when posting an job result update. This can happen when the server is busy and is not a critical error."
     end

--- a/lib/runner/runner.rb
+++ b/lib/runner/runner.rb
@@ -103,8 +103,8 @@ module Testbot::Runner
 
         job = Job.new(*([ self, next_job.split(',') ].flatten))
         if first_job_from_build?
-          fetch_code(job)
-          before_run(job)
+          job.fetch_code
+          job.before_run @config.max_instances
         end
 
         @last_build_id = job.build_id
@@ -125,25 +125,6 @@ module Testbot::Runner
     def max_jruby_instances?
       return unless @config.max_jruby_instances
       @instances.find_all { |thread, n, job| job.jruby? }.size >= @config.max_jruby_instances
-    end
-
-    def fetch_code(job)
-      system "rsync -az --timeout=300 --delete --delete-excluded -e ssh #{job.root}/ #{job.project}"
-    end
-
-    def before_run(job)
-      rvm_prefix = RubyEnv.rvm_prefix(job.project)
-      bundler_cmd = (RubyEnv.bundler?(job.project) ? [rvm_prefix, "bundle &&", rvm_prefix, "bundle exec"] : [rvm_prefix]).compact.join(" ")
-      command_prefix = "cd #{job.project} && export RAILS_ENV=test && export TEST_INSTANCES=#{@config.max_instances} && #{bundler_cmd}"
-
-      if File.exists?("#{job.project}/lib/tasks/testbot.rake")
-        system "#{command_prefix} rake testbot:before_run"
-      elsif File.exists?("#{job.project}/config/testbot/before_run.rb")
-        system "#{command_prefix} ruby config/testbot/before_run.rb"
-      else
-        # workaround to bundle within the correct env
-        system "#{command_prefix} ruby -e ''"
-      end
     end
 
     def first_job_from_build?

--- a/lib/runner/runner.rb
+++ b/lib/runner/runner.rb
@@ -65,6 +65,8 @@ module Testbot::Runner
         rescue Exception => ex
 #          break if [ 'SignalException', 'Interrupt' ].include?(ex.class.to_s)
           puts "The runner crashed, restarting. Error: #{ex.inspect} #{ex.class}"
+          puts "Caller: "
+          puts ex.backtrace.join("\n")
         end
 #      end
     end
@@ -98,6 +100,7 @@ module Testbot::Runner
         clear_completed_instances 
 
         next_job = Server.get("/jobs/next", :query => next_params) rescue nil
+        raise "fetch next job failed. response: #{next_job}" if next_job && next_job.code != 200
         last_check_found_a_job = (next_job != nil && next_job.body != "")
         next unless last_check_found_a_job
 

--- a/lib/server/build.rb
+++ b/lib/server/build.rb
@@ -26,9 +26,30 @@ module Testbot::Server
       end
     end
 
+    def all_jobs
+      Job.all.find_all { |j| j.build == self }
+    end
+
+    def done_jobs
+      Job.all.find_all { |j| j.done && j.build == self }
+    end
+
+    def remaining_jobs no_jruby=nil
+      Job.remaining_jobs(self.id, no_jruby)
+    end
+
     def destroy
-      Job.all.find_all { |j| j.build == self }.each { |job| job.destroy }
+      all_jobs.each { |job| job.destroy }
       super
+    end
+
+    def logln message
+      log "\n" if self.results[-1] != "\n"
+      log "#{message}\n"
+    end
+
+    def log message
+      self.results += message
     end
 
   end

--- a/lib/server/server.rb
+++ b/lib/server/server.rb
@@ -42,6 +42,7 @@ module Testbot::Server
   end
 
   get '/builds/:id' do
+    Job.release_jobs_taken_by_missing_runners!
     build = Build.find(params[:id])
     build.destroy if build.done
     { "done" => build.done, "results" => build.results, "success" => build.success }.to_json
@@ -54,10 +55,11 @@ module Testbot::Server
   end
 
   get '/jobs/next' do
-    next_job, runner = Job.next(params, @env['REMOTE_ADDR'])
-    if next_job
-      next_job.update(:taken_at => Time.now, :taken_by => runner)
-      [ next_job.id, next_job.build.id, next_job.project, next_job.root, next_job.type, (next_job.jruby == 1 ? 'jruby' : 'ruby'), next_job.files ].join(',')
+    job, runner = Job.next(params, @env['REMOTE_ADDR'])
+    if job
+      job.update(:taken_at => Time.now, :taken_by => runner)
+      job.build.logln "job##{job.id} assigned to runner<#{runner.hostname}>. unassigned jobs:#{job.build.remaining_jobs.count}/#{job.build.all_jobs.count} done jobs:#{job.build.done_jobs.count}/#{job.build.all_jobs.count} "
+      [ job.id, job.build.id, job.project, job.root, job.type, (job.jruby == 1 ? 'jruby' : 'ruby'), job.files ].join(',')
     end
   end
 

--- a/lib/server/server.rb
+++ b/lib/server/server.rb
@@ -21,6 +21,16 @@ module Testbot::Server
     def self.valid_version?(runner_version)
       Testbot.version == runner_version
     end
+
+    def self.runner_attributes runner
+      runner.attributes
+        .merge(build: nil)
+        .merge(status: status_for_runner(runner))
+    end
+
+    def self.status_for_runner runner
+      Job.all.find_all { |job| job.taken_by == runner }.map { |job| job.status }.join("/")
+    end
   end
 
   post '/builds' do
@@ -68,7 +78,7 @@ module Testbot::Server
   end
 
   get '/runners' do
-    Runner.find_all_available.map { |r| r.attributes }.to_json
+    Runner.find_all_available.map { |r| Server.runner_attributes r }.to_json
   end
 
   get '/runners/outdated' do

--- a/lib/server/status/status.html
+++ b/lib/server/status/status.html
@@ -16,7 +16,8 @@
           var idle_instances = 0;
           var total_instances = 0;
           $.each(runners, function(i, runner) {
-            $("#runners").append("<li>" + runner.hostname + ": " + runner.idle_instances + " / " + runner.max_instances + " idle</li>");
+            $("#runners").append("<li>[" + runner.hostname + "] idle: " + runner.idle_instances + " / " + runner.max_instances
+              + " status: " + runner.status + "</li>");
             idle_instances += runner.idle_instances;
             total_instances += runner.max_instances;
           });

--- a/test/server/server_test.rb
+++ b/test/server/server_test.rb
@@ -474,7 +474,7 @@ module Testbot::Server
         assert last_response.ok?
         assert_equal ([ { "version" => Testbot.version.to_s, "build" => nil, "hostname" => 'hostname1', "uid" => "00:01",
                           "idle_instances" => 2, "max_instances" => 4, "username" => 'testbot',
-                          "ip" => "127.0.0.1", "last_seen_at" => Runner.first.last_seen_at.to_s } ]),
+                          "ip" => "127.0.0.1", "last_seen_at" => Runner.first.last_seen_at.to_s, "status" => "" } ]),
                      JSON.parse(last_response.body)
       end
 


### PR DESCRIPTION
- ステータス画面で見た時に、以下のような表示に変更します。

```
[hostname] idle: 0 / 2 status: building/building
```
- runnerへのjobのassign時、およびrunnerが消えた時にログを出力します。
#### 確認方法

testbotをcheckoutして、

``` sh
bundle install
bundle exec rake build
```

としてtestbot-0.7.8.gemを作成し、

sc2-api-serverのディレクトリで

``` sh
gem install testbot-0.7.8.gem
testbot --server # (デーモン起動。testbot --server stop で止まる)
testbot --runner --connect localhost # (デーモン起動。testbot --runner stop で止まる)
testbot --rspec --connect localhost
```

のようにすれば http://localhost:2288/status  で様子を見ることができます。（virtual boxの場合は適当にportをtunnelしてください。完走までは時間がかかるので途中で止めて下さい）

https://www.pivotaltracker.com/story/show/107884290
